### PR TITLE
Master

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,3 +30,8 @@ FLUSH PRIVILEGES;
 COMMIT;
 MYSQL_SCRIPT
 sudo service mysql restart
+
+echo "enter your username in JCT"
+read Uname
+cp ~/.bashrc ~/.bashrc.bak
+sed -i s/\$C9_USER/$Uname/g ~/.bashrc


### PR DESCRIPTION
I have added 4 lines to change prompt on c9 (display username).
For this to happen, setup script will ask students for their name, and put it in .bashrc. Student are required to run 
. ~/.bashrc or (better in my opinion) to close the terminal and open new terminal for this to work.
If you approve, we will need to change the instructions PDF.
